### PR TITLE
Added "Website Name" Option to svbtle options page

### DIFF
--- a/wp-content/themes/svbtle/header.php
+++ b/wp-content/themes/svbtle/header.php
@@ -59,7 +59,7 @@
 <?php endforeach; ?>  
 				<?php if (!empty($options['website_link'])): ?>
 					<li class="link feed">
-						<a href="http://<?php echo $options['website_link'] ?>"><?php echo $options['website_link'] ?></a>
+						<a href="http://<?php echo $options['website_link'] ?>"><?php echo $options['website_name'] ?></a>
 					</li>
 				<?php endif ?>
 				<?php if (!empty($options['twitter_username'])): ?>

--- a/wp-content/themes/svbtle/theme-options.php
+++ b/wp-content/themes/svbtle/theme-options.php
@@ -48,7 +48,11 @@ function theme_options_do_page() {
 					<tr>
 						<th><?php _e( 'Website Link', 'wordpress-svbtle' ); ?></th>
 						<td><input class="regular-text" type="text" name="svbtle_options[website_link]" value="<?php esc_attr_e( $options['website_link'] ); ?>" /></td>
-					</tr>
+                    </tr>
+                    <tr>
+                        <th><?php _e( 'Website Name', 'wordpress-svbtle' ); ?></th>
+                        <td><input class="regular-text" type="text" name="svbtle_options[website_name]" value="<?php esc_attr_e( $options['website_name'] ); ?>" /></td>
+                    </tr>
 					<tr>
 						<th><?php _e( 'Twitter Username', 'wordpress-svbtle' ); ?></th>
 						<td><input class="regular-text" type="text" name="svbtle_options[twitter_username]" value="<?php esc_attr_e( $options['twitter_username'] ); ?>" /></td>


### PR DESCRIPTION
In the upstream version, the website link option allows you to add a link to a website on the wordpress sidebar. However, this link displays as the full URL, which for e.g. a LinkedIn or Facebook profile may be too long and unwieldy for a blog sidebar.

This change adds a field to the theme options for svbtle for Website Name, and uses that as the display name for the sidebar link.
